### PR TITLE
Remove -frename-registers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ ifeq ($(DEBUG), 1)
    CPUOPTS += -O0 -g
    CPUOPTS += -DOPENGL_DEBUG
 else
-   CPUOPTS += -O2 -DNDEBUG -fsigned-char -ffast-math -fno-strict-aliasing -fomit-frame-pointer -frename-registers -fvisibility=hidden
+   CPUOPTS += -O2 -DNDEBUG -fsigned-char -ffast-math -fno-strict-aliasing -fomit-frame-pointer -fvisibility=hidden
    CXXFLAGS += -fvisibility-inlines-hidden
 endif
 


### PR DESCRIPTION
This seems to only be supported for gcc. As it causes numerous warnings when compiled with clang it seems best to just remove it.
```
clang-4.0: warning: optimization flag '-frename-registers' is not supported [-Wignored-optimization-argument]
```