### PR TITLE
Raspberry Pi: use new vendor library names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ else ifneq (,$(findstring rpi,$(platform)))
    else
       LLE = 0
       CPUFLAGS += -DVC
-      GL_LIB := -L/opt/vc/lib -lGLESv2
+      GL_LIB := -L/opt/vc/lib -lbrcmGLESv2
       INCFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos -I/opt/vc/include/interface/vcos/pthreads
    endif
    WITH_DYNAREC=arm


### PR DESCRIPTION
Needed for new firmwares on Raspbian stretch and SDL 2.0.6.