### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # Mupen64Plus
 
-**Please read the [Wiki](https://github.com/GLupeN64/GLupeN64/wiki) for an explanation of the core options**
-
-**[Binary Builds](http://loganbuildbot.s3-website-us-east-1.amazonaws.com/)**
-
 Mupen64Plus is [mupen64plus](https://github.com/mupen64plus/mupen64plus-core) + [GLideN64](https://github.com/gonetz/GLideN64) + [libretro](http://www.libretro.com/)
 
-#### How is this different from [mupen64plus-libretro](https://github.com/libretro/mupen64plus-libretro)?
+#### How is this different from [Parallel-N64](https://github.com/libretro/parallel-n64)?
 
-mupen64plus-libretro implements multiple Graphics plugins. There are also code modifications that make it different than standalone mupen64plus.
+Parallel-N64 implements multiple Graphics plugins. There are also code modifications that make it different than standalone mupen64plus.
 
-Mupen64Plus uses GLideN64 (a graphics plugin that is not available in mupen64plus-libretro). The emulator code itself is identical to standalone mupen64plus.
+Mupen64Plus uses GLideN64 (a graphics plugin that is not available in Parallel-N64). The emulator code itself is identical to standalone mupen64plus.
 
 By choosing one graphics plugin (GLideN64), we will be able to keep the code in line with upstream, and maintaining the code will be much simpler.
 


### PR DESCRIPTION
Mupen64plus-libretro migrated to Parallel-N64 and Mupen64plus took the name of Mupen64plus-libretro. Some links are broken.