### PR TITLE
Disable x86 android jni builds

### DIFF
--- a/libretro/jni/Application.mk
+++ b/libretro/jni/Application.mk
@@ -1,3 +1,2 @@
-APP_ABI := armeabi-v7a,arm64-v8a,x86
+APP_ABI := armeabi-v7a arm64-v8a
 APP_STL := gnustl_static
-APP_PLATFORM ?= android-9


### PR DESCRIPTION
These have never been built and since the arch is currently broken,
it will prevent the working archs builds from completing.