### PR TITLE
GLideN64: fix build on FreeBSD (remove malloc.h)

### DIFF
--- a/GLideN64/src/DepthBuffer.cpp
+++ b/GLideN64/src/DepthBuffer.cpp
@@ -1,8 +1,3 @@
-#ifdef OS_MAC_OS_X
-#include <malloc/malloc.h>
-#else
-#include <malloc.h>
-#endif
 #include <assert.h>
 #include "OpenGL.h"
 #include "Combiner.h"

--- a/GLideN64/src/GLideNHQ/TxUtil.cpp
+++ b/GLideN64/src/GLideNHQ/TxUtil.cpp
@@ -24,7 +24,7 @@
 #include "TxUtil.h"
 #include "TxDbg.h"
 #include <zlib.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <assert.h>
 
 #if defined (OS_MAC_OS_X)


### PR DESCRIPTION
The [deprecated](https://stackoverflow.com/a/12973361) `malloc.h` header causes a build error on modern FreeBSD.

In `DepthBuffer.cpp`, malloc is not actually used (double checked with `include-what-you-use`), so I just removed it.

In `TxUtil.cpp`, switched to standard `stdlib.h`.