### PR TITLE
fix makefile for the raspberry pi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ ifeq ($(platform),)
    endif
 else ifneq (,$(findstring armv,$(platform)))
    override platform += unix
-else ifneq (,$(findstring rpi,$(platform)))
-   override platform += unix
 else ifneq (,$(findstring odroid,$(platform)))
    override platform += unix
 endif


### PR DESCRIPTION
don't add "unix" to platform for the rpi or else the later rpi logic isn't run.

@twinaphex 

Your commit https://github.com/libretro/mupen64plus-libretro/commit/e54a7279d5610602177c3fcaa6f747a7c0547cfd broke the makefile for the raspberry Pi. It's possible it's also broken for other platforms.

the code

```
else ifneq (,$(findstring rpi,$(platform)))
   override platform += unix
```

means that the later on rpi logic where we have

```
# Linux
ifneq (,$(findstring unix,$(platform)))
 
  ...

# Raspberry Pi
else ifneq (,$(findstring rpi,$(platform)))
```

won't ever get run. 