### PR TITLE
Added A7A7 platform, Added fix to Rpi/Mali devices and cleaned up

### DIFF
--- a/GLideN64/src/FrameBuffer.cpp
+++ b/GLideN64/src/FrameBuffer.cpp
@@ -625,7 +625,7 @@ void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _widt
 			m_pCurrent = nullptr;
 		} else {
 			m_pCurrent->m_resolved = false;
-#ifdef VC
+#if defined(VC) || defined(CLASSIC)
 			const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
 			glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
 #endif
@@ -757,7 +757,7 @@ void FrameBufferList::attachDepthBuffer()
 	if (m_pCurrent == nullptr)
 		return;
 
-#ifdef VC
+#if defined(VC) || defined(CLASSIC)
 	const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
 	glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
 #endif
@@ -991,7 +991,7 @@ void FrameBufferList::renderBuffer(u32 _address)
 	ogl.swapBuffers();
 	if (m_pCurrent != nullptr) {
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_pCurrent->m_FBO);
-#ifdef VC
+#if defined(VC) || defined(CLASSIC)
 		const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
 		glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
 #endif

--- a/GLideN64/src/FrameBuffer.cpp
+++ b/GLideN64/src/FrameBuffer.cpp
@@ -625,7 +625,7 @@ void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _widt
 			m_pCurrent = nullptr;
 		} else {
 			m_pCurrent->m_resolved = false;
-#if defined(VC) || defined(CLASSIC)
+#ifdef VC
 			const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
 			glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
 #endif
@@ -757,7 +757,7 @@ void FrameBufferList::attachDepthBuffer()
 	if (m_pCurrent == nullptr)
 		return;
 
-#if defined(VC) || defined(CLASSIC)
+#ifdef VC
 	const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
 	glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
 #endif
@@ -991,7 +991,7 @@ void FrameBufferList::renderBuffer(u32 _address)
 	ogl.swapBuffers();
 	if (m_pCurrent != nullptr) {
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_pCurrent->m_FBO);
-#if defined(VC) || defined(CLASSIC)
+#ifdef VC
 		const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
 		glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
 #endif

--- a/GLideN64/src/Textures.cpp
+++ b/GLideN64/src/Textures.cpp
@@ -526,7 +526,7 @@ void TextureCache::destroy()
 
 void TextureCache::_checkCacheSize()
 {
-#ifdef VC
+#if defined(VC) || defined(CLASSIC)
 	const size_t maxCacheSize = 15000;
 #else
 	const size_t maxCacheSize = 16384;

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,9 @@ else ifneq (,$(findstring rpi,$(platform)))
 # NESC, SNESC, C64 mini 
 else ifeq ($(platform), classic_armv7_a7)
 	TARGET := $(TARGET_NAME)_libretro.so
-    LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined
-    GLES = 1
-    GL_LIB := -lGLESv2
+	LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined
+	GLES = 1
+	GL_LIB := -lGLESv2
 	fpic := -fPIC
 	CPUFLAGS += -Ofast \
 	-flto=4 -fwhole-program -fuse-linker-plugin \
@@ -138,9 +138,11 @@ else ifeq ($(platform), classic_armv7_a7)
 	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
 	HAVE_NEON = 1
 	WITH_DYNAREC=arm
-    COREFLAGS += -DOS_LINUX
-    ASFLAGS = -f elf -d ELF_TYPE
-    LDFLAGS += -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+	COREFLAGS += -DOS_LINUX
+	ASFLAGS = -f elf -d ELF_TYPE
+	LDFLAGS += -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+	#This fixes the config for MALI based devices...
+	CPUFLAGS += -DCLASSIC
 	ifeq ($(shell echo `$(CC) -dumpversion` "< 4.9" | bc -l), 1)
 	  CFLAGS += -march=armv7-a
 	else

--- a/custom/GLideN64/mupenplus/Config_mupenplus.cpp
+++ b/custom/GLideN64/mupenplus/Config_mupenplus.cpp
@@ -127,7 +127,7 @@ void Config_LoadConfig()
 	config.generalEmulation.enableHWLighting = EnableHWLighting;
 	config.generalEmulation.correctTexrectCoords = CorrectTexrectCoords;
 	config.generalEmulation.enableNativeResTexrects = enableNativeResTexrects;
-	config.generalEmulatioenableLegacyBlending = enableLegacyBlending;
+	config.generalEmulation.enableLegacyBlending = enableLegacyBlending;
 #if defined(VC) || defined(CLASSIC)
 	config.frameBufferEmulation.copyDepthToRDRAM = 0;
 #else

--- a/custom/GLideN64/mupenplus/Config_mupenplus.cpp
+++ b/custom/GLideN64/mupenplus/Config_mupenplus.cpp
@@ -118,7 +118,7 @@ void Config_LoadConfig()
 	u32 hacks = config.generalEmulation.hacks;
 	config.resetToDefaults();
 	config.frameBufferEmulation.aspect = AspectRatio;
-#ifdef VC
+#if defined(VC) || defined(CLASSIC)
 	config.frameBufferEmulation.enable = 0;
 #else
 	config.frameBufferEmulation.enable = EnableFBEmulation;
@@ -127,8 +127,12 @@ void Config_LoadConfig()
 	config.generalEmulation.enableHWLighting = EnableHWLighting;
 	config.generalEmulation.correctTexrectCoords = CorrectTexrectCoords;
 	config.generalEmulation.enableNativeResTexrects = enableNativeResTexrects;
-	config.generalEmulation.enableLegacyBlending = enableLegacyBlending;
+	config.generalEmulatioenableLegacyBlending = enableLegacyBlending;
+#if defined(VC) || defined(CLASSIC)
+	config.frameBufferEmulation.copyDepthToRDRAM = 0;
+#else
 	config.frameBufferEmulation.copyDepthToRDRAM = EnableCopyDepthToRDRAM;
+#endif
 #if defined(GLES2) && !defined(ANDROID)
 	config.frameBufferEmulation.copyToRDRAM = Config::ctDisable;
 #else

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -151,7 +151,11 @@ static void setup_variables(void)
             "MSAA level; 0|2|4|8|16" },
 #endif
         { "mupen64plus-EnableFBEmulation",
-            "Framebuffer Emulation; True|False" },
+#if defined(VC) || defined(CLASSIC)
+            "Framebuffer Emulation; False|True" },
+#else
+            "Framebuffer Emulation; False|True" },
+#endif				
         { "mupen64plus-EnableCopyColorToRDRAM",
 #ifndef HAVE_OPENGLES
             "Color buffer to RDRAM; Async|Sync|Off" },
@@ -159,7 +163,11 @@ static void setup_variables(void)
             "Color buffer to RDRAM; Off|Async|Sync" },
 #endif
         { "mupen64plus-EnableCopyDepthToRDRAM",
+#if defined(VC) || defined(CLASSIC)
+            "Depth buffer to RDRAM; Off|Software|FromMem" },
+#else
             "Depth buffer to RDRAM; Software|FromMem|Off" },
+#endif
         { "mupen64plus-EnableHWLighting",
             "Hardware per-pixel lighting; False|True" },
         { "mupen64plus-CorrectTexrectCoords",


### PR DESCRIPTION
- Added Classic Platform structure - ARMv7 Cortex A7 build
- Disabled FB emulation to prevent framebuffer emulation crash on MALI devices. (Classics)
- Disbaled copyDepthToRDRAM for RPI and Classics as it caused log spam and doesn't work on < GLES 3.1 
 (This could be tied down to HAVE_GLES3 or HAVE_OPENGL > 4 but didn't want to possibly break any other platform.)
- Reduced Texture cache for Classics to 15000
- Cleaned up Make
- Changed default values for RPI and Classic to reflect the disabling of features on the effected platforms.