### PR TITLE
[GLideNHQ] use <GLES2/gl2ext.h> if GLES3 is enabled

### DIFF
--- a/GLideN64/src/GLideNHQ/TxInternal.h
+++ b/GLideN64/src/GLideNHQ/TxInternal.h
@@ -46,11 +46,11 @@
 #define GL_COLOR_INDEX8_EXT  0x80E5
 #elif defined(GLES3)
 #include <GLES3/gl3.h>
-#include <GLES3/gl3ext.h>
+#include <GLES2/gl2ext.h>
 #define GL_COLOR_INDEX8_EXT  0x80E5
 #elif defined(GLES3_1)
 #include <GLES3/gl31.h>
-#include <GLES3/gl3ext.h>
+#include <GLES2/gl2ext.h>
 #define GL_COLOR_INDEX8_EXT  0x80E5
 #elif defined(OS_MAC_OS_X)
 #include <OpenGL/gl.h>


### PR DESCRIPTION
This allows you to build mupen64plus-libretro with GLES3 if there is no `gl3ext.h` in your include files which should be normally an empty file anyway. This PR fixes the build with latest LibreELEC master for RK3399 and `FORCE_GLES3=1` flag.

OpenGL ES 3.0 Headers:
https://www.khronos.org/registry/OpenGL/index_es.php#headers3